### PR TITLE
PartialReductionOpInterface: Add optional callback returning value broadcast to initial tensor

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -567,11 +567,12 @@ struct ForallReductionTilingResult {
 /// %6 = linalg.generic %1 ["parallel", "reduction"]
 ///   : tensor<7x4xf32> -> tensor<7xf32>
 /// ```
-FailureOr<ForallReductionTilingResult>
-tileReductionUsingForall(RewriterBase &b, PartialReductionOpInterface op,
-                         ArrayRef<OpFoldResult> numThreads,
-                         ArrayRef<OpFoldResult> tileSizes = {},
-                         std::optional<ArrayAttr> mapping = std::nullopt);
+FailureOr<ForallReductionTilingResult> tileReductionUsingForall(
+    RewriterBase &b, PartialReductionOpInterface op,
+    ArrayRef<OpFoldResult> numThreads, ArrayRef<OpFoldResult> tileSizes = {},
+    std::optional<ArrayAttr> mapping = std::nullopt,
+    function_ref<std::optional<Value>(Operation *, OpBuilder &)>
+        extraGetNeutralElement = nullptr);
 
 /// All indices returned by IndexOp should be invariant with respect to
 /// tiling. Therefore, if an operation is tiled, we have to transform the

--- a/mlir/include/mlir/Interfaces/TilingInterface.td
+++ b/mlir/include/mlir/Interfaces/TilingInterface.td
@@ -176,7 +176,8 @@ def PartialReductionOpInterface : OpInterface<"PartialReductionOpInterface"> {
             "OpBuilder &":$b,
             "Location ":$loc,
             "ArrayRef<OpFoldResult>":$sizes,
-            "ArrayRef<int>":$reductionDim),
+            "ArrayRef<int>":$reductionDim,
+            "function_ref<std::optional<Value>(Operation*, OpBuilder&)>":$generateInitialValue),
         /*methodBody=*/"",
         /*defaultImplementation=*/[{
           return failure();

--- a/mlir/lib/Dialect/Linalg/Transforms/Tiling.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Tiling.cpp
@@ -610,7 +610,9 @@ tileLinalgOpImpl(RewriterBase &b, LinalgOp op, ArrayRef<OpFoldResult> tileSizes,
 FailureOr<linalg::ForallReductionTilingResult> linalg::tileReductionUsingForall(
     RewriterBase &b, PartialReductionOpInterface op,
     ArrayRef<OpFoldResult> numThreads, ArrayRef<OpFoldResult> tileSizes,
-    std::optional<ArrayAttr> mapping) {
+    std::optional<ArrayAttr> mapping,
+    function_ref<std::optional<Value>(Operation *, OpBuilder &)>
+        extraGetNeutralElement) {
   Location loc = op.getLoc();
   OpBuilder::InsertionGuard g(b);
 
@@ -656,8 +658,8 @@ FailureOr<linalg::ForallReductionTilingResult> linalg::tileReductionUsingForall(
 
   // 1. Create the inital tensor value.
   FailureOr<Operation *> identityTensor =
-      op.generateInitialTensorForPartialReduction(b, loc, numThreads,
-                                                  reductionDim);
+      op.generateInitialTensorForPartialReduction(
+          b, loc, numThreads, reductionDim, extraGetNeutralElement);
   if (failed(identityTensor))
     return b.notifyMatchFailure(op,
                                 "cannot create a tensor of identity value.");

--- a/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
@@ -436,7 +436,7 @@ mlir::scf::tileReductionUsingScf(PatternRewriter &b,
   // 1. create the inital tensor value.
   FailureOr<Operation *> identityTensor =
       op.generateInitialTensorForPartialReduction(b, loc, tileSize,
-                                                  reductionDim);
+                                                  reductionDim, nullptr);
   if (failed(identityTensor))
     return b.notifyMatchFailure(op,
                                 "cannot create a tensor of identity value.");


### PR DESCRIPTION
This change adds an extra parameter to the function `generateInitialTensorForPartialReduction` of
`PartialReductionOpInterface` that allows for the specification of a callback function that returns a value that is broadcast to the tensor generated by the function. This enables the generation of initial tensors for partial reductions with a custom result type.