### PR TITLE
Add Region Branch Op interface and related methods to SCF::ForallOp

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -663,6 +663,12 @@ def ForallOp : SCF_Op<"forall", [
                                  Location loc);
 
     InParallelOp getTerminator();
+
+    /// Return operands used when entering the region at 'index'. These operands
+    /// correspond to the shared output operands, i.e., those excluding the
+    /// induction variable. Since there can be only one region, 0 is the only
+    /// valid value for `index`.
+    OperandRange getSuccessorEntryOperands(std::optional<unsigned> index);
   }];
 }
 

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -356,6 +356,7 @@ def ForallOp : SCF_Op<"forall", [
        AutomaticAllocationScope,
        RecursiveMemoryEffects,
        SingleBlockImplicitTerminator<"scf::InParallelOp">,
+       DeclareOpInterfaceMethods<RegionBranchOpInterface>,
      ]> {
   let summary = "evaluate a block multiple times in parallel";
   let description = [{
@@ -814,6 +815,7 @@ def ParallelOp : SCF_Op<"parallel",
      AttrSizedOperandSegments,
      DeclareOpInterfaceMethods<LoopLikeOpInterface>,
      RecursiveMemoryEffects,
+     DeclareOpInterfaceMethods<RegionBranchOpInterface>,
      SingleBlockImplicitTerminator<"scf::YieldOp">]> {
   let summary = "parallel for operation";
   let description = [{

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -1471,6 +1471,25 @@ void ForallOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.add<DimOfForallOp, ForallOpControlOperandsFolder>(context);
 }
 
+/// Given the region at `index`, or the parent operation if `index` is None,
+/// return the successor regions. These are the regions that may be selected
+/// during the flow of control. `operands` is a set of optional attributes that
+/// correspond to a constant value for each operand, or null if that operand is
+/// not a constant.
+void ForallOp::getSuccessorRegions(std::optional<unsigned> index,
+                                   ArrayRef<Attribute> operands,
+                                   SmallVectorImpl<RegionSuccessor> &regions) {
+  // If the predecessor is ForallOp, branch into the body with empty arguments.
+  if (!index) {
+    regions.push_back(RegionSuccessor(&getRegion()));
+    return;
+  }
+
+  // Otherwise, the loop should branch back to the parent operation.
+  assert(*index == 0 && "expected loop region");
+  regions.push_back(RegionSuccessor());
+}
+
 //===----------------------------------------------------------------------===//
 // InParallelOp
 //===----------------------------------------------------------------------===//
@@ -2772,6 +2791,26 @@ void ParallelOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
   results.add<CollapseSingleIterationLoops, RemoveEmptyParallelLoops,
               MergeNestedParallelLoops>(context);
+}
+
+/// Given the region at `index`, or the parent operation if `index` is None,
+/// return the successor regions. These are the regions that may be selected
+/// during the flow of control. `operands` is a set of optional attributes that
+/// correspond to a constant value for each operand, or null if that operand is
+/// not a constant.
+void ParallelOp::getSuccessorRegions(
+    std::optional<unsigned> index, ArrayRef<Attribute> operands,
+    SmallVectorImpl<RegionSuccessor> &regions) {
+  // If the predecessor is ParallelOp, branch into the body with empty
+  // arguments.
+  if (!index) {
+    regions.push_back(RegionSuccessor(&getRegion()));
+    return;
+  }
+
+  assert(*index == 0 && "expected loop region");
+  // Otherwise, the loop should branch back to the parent operation.
+  regions.push_back(RegionSuccessor());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Currently, backward dataflow analysis is not able to correctly reconstruct the flow of data starting from within the region of an `scf.forall` op to values of the parent region. This is because `ForallOp` does not implement `RegionBranchOpInterface`  and does not implement the method `getSuccessorEntryOperands()`. This PR cherry-picks the [upstream commit ](https://github.com/llvm/llvm-project/commit/e8bfec26a6dace4f7d8d21e74d1e8d05f9714a63)for the implementation of `RegionBranchOpInterface` and adds a commit on top of it for `getSuccessorEntryOperands()`.