### PR TITLE
[mlir][parser] Add control over diagnostics in method parsing optional integers

### DIFF
--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -779,6 +779,8 @@ public:
 
   /// Parse an optional integer value from the stream.
   virtual OptionalParseResult parseOptionalInteger(APInt &result) = 0;
+  virtual OptionalParseResult parseOptionalInteger(APInt &result,
+                                                   bool emitErrors) = 0;
   virtual OptionalParseResult parseOptionalDecimalInteger(APInt &result) = 0;
 
 private:
@@ -805,9 +807,11 @@ private:
 
 public:
   template <typename IntT>
-  OptionalParseResult parseOptionalInteger(IntT &result) {
-    return parseOptionalIntegerAndCheck(
-        result, [&](APInt &result) { return parseOptionalInteger(result); });
+  OptionalParseResult parseOptionalInteger(IntT &result,
+                                           bool emitErrors = false) {
+    return parseOptionalIntegerAndCheck(result, [&](APInt &result) {
+      return parseOptionalInteger(result, emitErrors);
+    });
   }
 
   template <typename IntT>

--- a/mlir/lib/AsmParser/AsmParserImpl.h
+++ b/mlir/lib/AsmParser/AsmParserImpl.h
@@ -354,6 +354,13 @@ public:
     return parser.parseOptionalInteger(result);
   }
 
+  /// Parse an optional integer value from the stream. Emit errors
+  /// only if `emitErrors` is `true`.
+  OptionalParseResult parseOptionalInteger(APInt &result,
+                                           bool emitErrors) override {
+    return parser.parseOptionalInteger(result, emitErrors);
+  }
+
   /// Parse an optional integer value from the stream.
   OptionalParseResult parseOptionalDecimalInteger(APInt &result) override {
     return parser.parseOptionalDecimalInteger(result);

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -268,11 +268,11 @@ InFlightDiagnostic Parser::emitWrongTokenError(const Twine &message) {
 
 /// Consume the specified token if present and return success.  On failure,
 /// output a diagnostic and return failure.
-ParseResult Parser::parseToken(Token::Kind expectedToken,
-                               const Twine &message) {
+ParseResult Parser::parseToken(Token::Kind expectedToken, const Twine &message,
+                               bool emitErrors) {
   if (consumeIf(expectedToken))
     return success();
-  return emitWrongTokenError(message);
+  return emitErrors ? emitWrongTokenError(message) : failure();
 }
 
 /// Parses a quoted string token if present.
@@ -287,7 +287,8 @@ ParseResult Parser::parseOptionalString(std::string *string) {
 }
 
 /// Parse an optional integer value from the stream.
-OptionalParseResult Parser::parseOptionalInteger(APInt &result) {
+OptionalParseResult Parser::parseOptionalInteger(APInt &result,
+                                                 bool emitErrors) {
   // Parse `false` and `true` keywords as 0 and 1 respectively.
   if (consumeIf(Token::kw_false)) {
     result = false;
@@ -304,13 +305,18 @@ OptionalParseResult Parser::parseOptionalInteger(APInt &result) {
 
   bool negative = consumeIf(Token::minus);
   Token curTok = getToken();
-  if (parseToken(Token::integer, "expected integer value"))
+  if (parseToken(Token::integer, "expected integer value", emitErrors))
     return failure();
 
   StringRef spelling = curTok.getSpelling();
   bool isHex = spelling.size() > 1 && spelling[1] == 'x';
-  if (spelling.getAsInteger(isHex ? 0 : 10, result))
-    return emitError(curTok.getLoc(), "integer value too large");
+  if (spelling.getAsInteger(isHex ? 0 : 10, result)) {
+    if (emitErrors) {
+      return emitError(curTok.getLoc(), "integer value too large");
+    } else {
+      return failure();
+    }
+  }
 
   // Make sure we have a zero at the top so we return the right signedness.
   if (result.isNegative())
@@ -321,6 +327,11 @@ OptionalParseResult Parser::parseOptionalInteger(APInt &result) {
     result.negate();
 
   return success();
+}
+
+/// Parse an optional integer value from the stream.
+OptionalParseResult Parser::parseOptionalInteger(APInt &result) {
+  return parseOptionalInteger(result, true);
 }
 
 /// Parse an optional integer value only in decimal format from the stream.

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -142,12 +142,18 @@ public:
     state.curToken = state.lex.lexToken();
   }
 
-  /// Consume the specified token if present and return success.  On failure,
-  /// output a diagnostic and return failure.
-  ParseResult parseToken(Token::Kind expectedToken, const Twine &message);
+  /// Consume the specified token if present and return success.  On
+  /// failure, output a diagnostic and return failure. if `emitErrors`
+  /// is false, no diagnostic is emitted upon failure.
+  ParseResult parseToken(Token::Kind expectedToken, const Twine &message,
+                         bool emitErrors = true);
 
   /// Parses a quoted string token if present.
   ParseResult parseOptionalString(std::string *string);
+
+  /// Parse an optional integer value from the stream. Only emit
+  /// errors if `emitErrors` is true.
+  OptionalParseResult parseOptionalInteger(APInt &result, bool emitErrors);
 
   /// Parse an optional integer value from the stream.
   OptionalParseResult parseOptionalInteger(APInt &result);


### PR DESCRIPTION
By default, an invocation of `AsmParser::parseOptionalInteger` creates and displays diagnostic messages when parsing fails. This is inconvenient when `parseOptionalInteger` is used as a part of a parser function that attempts to parse multiple, alternative values, as parsing of another value may succeed afterwards, yet displaying an error message about the failed integer parsing.

This commit adds a new overload of `parseOptionalInteger` with an additional boolean argument `emitErrors` for control over diagnostics. If set to `true`, the method behaves exactly as the existing overload, displaying messages when parsing fails. If set to `false`, no diagnostics are displayed at all.