### PR TITLE
[mlir] Add access to large values for DynamicAPInt via operator APInt()

### DIFF
--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -153,6 +153,12 @@ public:
       return getSmall();
     return static_cast<int64_t>(getLarge());
   }
+  LLVM_ATTRIBUTE_ALWAYS_INLINE explicit operator APInt() const {
+    if (isSmall())
+      return APInt(64, getSmall());
+
+    return static_cast<APInt>(getLarge());
+  }
 
   bool operator==(const DynamicAPInt &O) const;
   bool operator!=(const DynamicAPInt &O) const;

--- a/llvm/include/llvm/ADT/SlowDynamicAPInt.h
+++ b/llvm/include/llvm/ADT/SlowDynamicAPInt.h
@@ -41,6 +41,7 @@ public:
   LLVM_ABI explicit SlowDynamicAPInt(const APInt &Val);
   LLVM_ABI SlowDynamicAPInt &operator=(int64_t Val);
   LLVM_ABI explicit operator int64_t() const;
+  LLVM_ABI explicit operator APInt() const;
   LLVM_ABI SlowDynamicAPInt operator-() const;
   LLVM_ABI bool operator==(const SlowDynamicAPInt &O) const;
   LLVM_ABI bool operator!=(const SlowDynamicAPInt &O) const;

--- a/llvm/lib/Support/SlowDynamicAPInt.cpp
+++ b/llvm/lib/Support/SlowDynamicAPInt.cpp
@@ -22,6 +22,7 @@ SlowDynamicAPInt &SlowDynamicAPInt::operator=(int64_t Val) {
   return *this = SlowDynamicAPInt(Val);
 }
 SlowDynamicAPInt::operator int64_t() const { return Val.getSExtValue(); }
+SlowDynamicAPInt::operator APInt() const { return Val; }
 
 hash_code llvm::detail::hash_value(const SlowDynamicAPInt &X) {
   return hash_value(X.Val);


### PR DESCRIPTION
Currently, `DynamicAPInt` only provides ways to access the current value if it is small (i.e., as an `int64_t`), but for large values, it does not provide access to the underlying `SlowDynamicAPInt` or `APInt`.

This commit adds `DynamicAPInt::operator APInt()`, which allows for access to the underlying large value.